### PR TITLE
Implement Checkout via PayOS and COD

### DIFF
--- a/src/main/java/com/nhanab/shop/controller/CheckoutController.java
+++ b/src/main/java/com/nhanab/shop/controller/CheckoutController.java
@@ -1,11 +1,12 @@
 package com.nhanab.shop.controller;
 
 import com.nhanab.shop.dto.checkout.CheckoutRequest;
+import com.nhanab.shop.dto.checkout.PayOSResponse;
+import com.nhanab.shop.dto.order.OrderDto;
 import com.nhanab.shop.service.CheckoutService;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -14,7 +15,14 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 public class CheckoutController {
     private final CheckoutService checkoutService;
-    @PostMapping
-    public ResponseEntity<String> checkout(CheckoutRequest checkoutRequest) {
+
+    @PostMapping("/cod")
+    public OrderDto checkoutCod(@RequestBody CheckoutRequest checkoutRequest) {
+        return checkoutService.checkoutWithCod(checkoutRequest);
+    }
+
+    @PostMapping("/payos")
+    public PayOSResponse checkoutPayOS(@RequestBody CheckoutRequest checkoutRequest) {
+        return checkoutService.checkoutWithPayos(checkoutRequest);
     }
 }

--- a/src/main/java/com/nhanab/shop/controller/OrderController.java
+++ b/src/main/java/com/nhanab/shop/controller/OrderController.java
@@ -6,6 +6,7 @@ import com.nhanab.shop.dto.order.UpdateOrderRequest;
 import com.nhanab.shop.dto.payload.ErrorResponse;
 import com.nhanab.shop.exception.ResourceNotFoundException;
 import com.nhanab.shop.model.Order;
+import com.nhanab.shop.model.PaymentMethod;
 import com.nhanab.shop.service.OrderService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -82,7 +83,7 @@ public class OrderController {
     )
     @PostMapping
     public OrderDto createOrder(@RequestBody OrderRequest orderRequest) {
-        return orderService.placeOrder(orderRequest);
+        return orderService.placeOrder(orderRequest, PaymentMethod.COD);
     }
 
     @Operation(

--- a/src/main/java/com/nhanab/shop/dto/checkout/CheckoutRequest.java
+++ b/src/main/java/com/nhanab/shop/dto/checkout/CheckoutRequest.java
@@ -2,6 +2,7 @@ package com.nhanab.shop.dto.checkout;
 
 import com.nhanab.shop.dto.cart.CartItemRequest;
 import com.nhanab.shop.dto.order.ShippingAddress;
+import com.nhanab.shop.dto.order.OrderBuyer;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -16,6 +17,7 @@ public class CheckoutRequest {
 
     private UUID userId;
     private Set<CartItemRequest> cartItems;
+    private OrderBuyer buyerInfo;
     private ShippingAddress shippingAddress;
 
     private String paymentMethod;

--- a/src/main/java/com/nhanab/shop/dto/checkout/PayOSResponse.java
+++ b/src/main/java/com/nhanab/shop/dto/checkout/PayOSResponse.java
@@ -1,0 +1,13 @@
+package com.nhanab.shop.dto.checkout;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class PayOSResponse {
+    private String checkoutUrl;
+    private String paymentUrl;
+}

--- a/src/main/java/com/nhanab/shop/model/Order.java
+++ b/src/main/java/com/nhanab/shop/model/Order.java
@@ -1,6 +1,7 @@
 package com.nhanab.shop.model;
 
 import com.nhanab.shop.dto.order.ShippingAddress;
+import com.nhanab.shop.model.OrderStatus;
 import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.Setter;
@@ -23,7 +24,9 @@ public class Order {
     private User user;
 
     private LocalDateTime orderDate;
-    private String orderStatus;
+
+    @Enumerated(EnumType.STRING)
+    private OrderStatus orderStatus = OrderStatus.PENDING;
     private BigDecimal totalAmount;
     private BigDecimal taxAmount;
 

--- a/src/main/java/com/nhanab/shop/model/OrderStatus.java
+++ b/src/main/java/com/nhanab/shop/model/OrderStatus.java
@@ -1,0 +1,7 @@
+package com.nhanab.shop.model;
+
+public enum OrderStatus {
+    PENDING,
+    PAID,
+    CANCELLED
+}

--- a/src/main/java/com/nhanab/shop/model/Payment.java
+++ b/src/main/java/com/nhanab/shop/model/Payment.java
@@ -3,6 +3,8 @@ package com.nhanab.shop.model;
 import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.Setter;
+import com.nhanab.shop.model.PaymentMethod;
+import com.nhanab.shop.model.PaymentStatus;
 
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
@@ -21,11 +23,13 @@ public class Payment {
     @JoinColumn(name = "order_id")
     private Order order;
 
+    @Enumerated(EnumType.STRING)
     @Column(name = "payment_method")
-    private String paymentMethod;
+    private PaymentMethod paymentMethod;
 
+    @Enumerated(EnumType.STRING)
     @Column(name = "payment_status")
-    private String paymentStatus;
+    private PaymentStatus paymentStatus;
 
     private BigDecimal  paymentAmount;
 

--- a/src/main/java/com/nhanab/shop/model/PaymentMethod.java
+++ b/src/main/java/com/nhanab/shop/model/PaymentMethod.java
@@ -1,0 +1,6 @@
+package com.nhanab.shop.model;
+
+public enum PaymentMethod {
+    PAYOS,
+    COD
+}

--- a/src/main/java/com/nhanab/shop/model/PaymentStatus.java
+++ b/src/main/java/com/nhanab/shop/model/PaymentStatus.java
@@ -1,0 +1,6 @@
+package com.nhanab.shop.model;
+
+public enum PaymentStatus {
+    PENDING,
+    PAID
+}

--- a/src/main/java/com/nhanab/shop/service/CheckoutService.java
+++ b/src/main/java/com/nhanab/shop/service/CheckoutService.java
@@ -1,5 +1,10 @@
 package com.nhanab.shop.service;
 
-public interface CheckoutService {
+import com.nhanab.shop.dto.checkout.CheckoutRequest;
+import com.nhanab.shop.dto.checkout.PayOSResponse;
+import com.nhanab.shop.dto.order.OrderDto;
 
+public interface CheckoutService {
+    OrderDto checkoutWithCod(CheckoutRequest request);
+    PayOSResponse checkoutWithPayos(CheckoutRequest request);
 }

--- a/src/main/java/com/nhanab/shop/service/OrderService.java
+++ b/src/main/java/com/nhanab/shop/service/OrderService.java
@@ -3,13 +3,13 @@ package com.nhanab.shop.service;
 import com.nhanab.shop.dto.order.OrderDto;
 import com.nhanab.shop.dto.order.OrderRequest;
 import com.nhanab.shop.dto.order.UpdateOrderRequest;
-import com.nhanab.shop.model.Order;
+import com.nhanab.shop.model.PaymentMethod;
 
 import java.util.List;
 import java.util.UUID;
 
 public interface OrderService {
-    OrderDto placeOrder(OrderRequest orderRequest);
+    OrderDto placeOrder(OrderRequest orderRequest, PaymentMethod paymentMethod);
 
     OrderDto getOrderById(UUID orderId);
 

--- a/src/main/java/com/nhanab/shop/service/impl/CheckoutServiceImpl.java
+++ b/src/main/java/com/nhanab/shop/service/impl/CheckoutServiceImpl.java
@@ -1,0 +1,40 @@
+package com.nhanab.shop.service.impl;
+
+import com.nhanab.shop.dto.checkout.CheckoutRequest;
+import com.nhanab.shop.dto.checkout.PayOSResponse;
+import com.nhanab.shop.dto.order.OrderDto;
+import com.nhanab.shop.dto.order.OrderRequest;
+import com.nhanab.shop.model.PaymentMethod;
+import com.nhanab.shop.service.CheckoutService;
+import com.nhanab.shop.service.OrderService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class CheckoutServiceImpl implements CheckoutService {
+
+    private final OrderService orderService;
+    private final PayOSClient payOSClient;
+
+    @Override
+    public OrderDto checkoutWithCod(CheckoutRequest request) {
+        OrderRequest orderRequest = toOrderRequest(request);
+        return orderService.placeOrder(orderRequest, PaymentMethod.COD);
+    }
+
+    @Override
+    public PayOSResponse checkoutWithPayos(CheckoutRequest request) {
+        OrderRequest orderRequest = toOrderRequest(request);
+        OrderDto order = orderService.placeOrder(orderRequest, PaymentMethod.PAYOS);
+        return payOSClient.createPayment(order.getOrderId());
+    }
+
+    private OrderRequest toOrderRequest(CheckoutRequest request) {
+        OrderRequest orderRequest = new OrderRequest();
+        orderRequest.setUserId(request.getUserId());
+        orderRequest.setShippingAddress(request.getShippingAddress());
+        orderRequest.setBuyerInfo(request.getBuyerInfo());
+        return orderRequest;
+    }
+}

--- a/src/main/java/com/nhanab/shop/service/impl/OrderServiceImpl.java
+++ b/src/main/java/com/nhanab/shop/service/impl/OrderServiceImpl.java
@@ -32,7 +32,7 @@ public class OrderServiceImpl implements OrderService {
 
     @Override
     @Transactional
-    public OrderDto placeOrder(OrderRequest request) {
+    public OrderDto placeOrder(OrderRequest request, PaymentMethod paymentMethod) {
         User user = userRepository.findById(request.getUserId()).orElseThrow(() -> new ResourceNotFoundException("User not found"));
 
         Cart cart = cartRepository.findByIdWithItems(user.getCart().getId()).orElseThrow(() -> new ResourceNotFoundException("Cart not found"));
@@ -45,7 +45,7 @@ public class OrderServiceImpl implements OrderService {
         Order order = new Order();
         order.setUser(user);
         order.setOrderDate(LocalDateTime.now());
-        order.setOrderStatus("PENDING");
+        order.setOrderStatus(OrderStatus.PENDING);
         order.setShippingAddress(request.getShippingAddress());
         order.setPhoneNumber(request.getBuyerInfo().getPhoneNumber());
         order.setCustomerName(request.getBuyerInfo().getName());
@@ -86,8 +86,8 @@ public class OrderServiceImpl implements OrderService {
         Payment payment = new Payment();
         payment.setPaymentAmount(order.getTotalAmount().add(order.getTaxAmount()));
         payment.setOrder(order);
-        payment.setPaymentMethod("BANKING");
-        payment.setPaymentStatus("PENDING");
+        payment.setPaymentMethod(paymentMethod);
+        payment.setPaymentStatus(PaymentStatus.PENDING);
 
         order.setPayment(payment);
         order = orderRepository.save(order);
@@ -131,8 +131,8 @@ public class OrderServiceImpl implements OrderService {
     @Override
     public void cancelOrder(UUID orderId) {
         Order order = orderRepository.findById(orderId).orElseThrow(() -> new ResourceNotFoundException("Order not found"));
-        if (order.getOrderStatus().equals("PENDING")) {
-            order.setOrderStatus("CANCELLED");
+        if (order.getOrderStatus() == OrderStatus.PENDING) {
+            order.setOrderStatus(OrderStatus.CANCELLED);
             order = orderRepository.save(order);
         }
     }

--- a/src/main/java/com/nhanab/shop/service/impl/PayOSClient.java
+++ b/src/main/java/com/nhanab/shop/service/impl/PayOSClient.java
@@ -1,0 +1,14 @@
+package com.nhanab.shop.service.impl;
+
+import com.nhanab.shop.dto.checkout.PayOSResponse;
+import org.springframework.stereotype.Component;
+
+import java.util.UUID;
+
+@Component
+public class PayOSClient {
+    public PayOSResponse createPayment(UUID orderId) {
+        String base = "https://payos.example.com/" + orderId;
+        return new PayOSResponse(base + "/checkout", base + "/payment");
+    }
+}


### PR DESCRIPTION
## Summary
- add enums for order and payment status
- update `Order` and `Payment` models to use enums
- extend checkout request with buyer info and implement `CheckoutService`
- support PayOS client for generating checkout URLs
- refactor controllers and services to use new checkout flow